### PR TITLE
Fix cropping on mobile devices

### DIFF
--- a/module/VisualCeption.php
+++ b/module/VisualCeption.php
@@ -250,8 +250,8 @@ class VisualCeption extends CodeceptionModule
 
         $imageCoords['offset_x'] = (string)$this->webDriver->executeScript('return jQuery( "' . $elementId . '" ).offset().left;');
         $imageCoords['offset_y'] = (string)$this->webDriver->executeScript('return jQuery( "' . $elementId . '" ).offset().top;');
-        $imageCoords['width'] = (string)$this->webDriver->executeScript('return jQuery( "' . $elementId . '" ).width();');
-        $imageCoords['height'] = (string)$this->webDriver->executeScript('return jQuery( "' . $elementId . '" ).height();');
+        $imageCoords['width'] = (string)$this->webDriver->executeScript('return jQuery( "' . $elementId . '" ).width() * window.devicePixelRatio;');
+        $imageCoords['height'] = (string)$this->webDriver->executeScript('return jQuery( "' . $elementId . '" ).height() * window.devicePixelRatio;');
 
         return $imageCoords;
     }


### PR DESCRIPTION
If I create a screenshot on a mobile device, it may be larger than what `$(window).width()` returns (for example - retina screens). This causes a bug in the code that crops the image to smaller size.

Multiplying the width by the `devicePixelRatio` solves this issue.