### PR TITLE
Add identifier to failed test name

### DIFF
--- a/module/ImageDeviationException.php
+++ b/module/ImageDeviationException.php
@@ -4,12 +4,14 @@ namespace Codeception\Module;
 
 class ImageDeviationException extends \PHPUnit_Framework_AssertionFailedError
 {
+    private $identifier;
     private $expectedImage;
     private $currentImage;
     private $deviationImage;
 
-    public function __construct($message, $expectedImage, $currentImage, $deviationImage)
+    public function __construct($message, $identifier, $expectedImage, $currentImage, $deviationImage)
     {
+        $this->identifier = $identifier;
         $this->deviationImage = $deviationImage;
         $this->currentImage = $currentImage;
         $this->expectedImage = $expectedImage;
@@ -17,7 +19,12 @@ class ImageDeviationException extends \PHPUnit_Framework_AssertionFailedError
         parent::__construct($message);
     }
 
-    public function getDeviationImage( )
+    public function getIdentifier()
+    {
+        return $this->identifier;
+    }
+
+    public function getDeviationImage()
     {
         return $this->deviationImage;
     }

--- a/module/VisualCeption.php
+++ b/module/VisualCeption.php
@@ -90,7 +90,7 @@ class VisualCeption extends CodeceptionModule
     public function _failed(\Codeception\TestInterface $test, $fail)
     {
         if ($fail instanceof ImageDeviationException) {
-            $this->failed[Descriptor::getTestAsString($test)] = $fail;
+            $this->failed[$test->getSignature() . '.' . $fail->getIdentifier()] = $fail;
         }
     }
 
@@ -149,6 +149,7 @@ class VisualCeption extends CodeceptionModule
             $deviationResult["deviationImage"]->writeImage($compareScreenshotPath);
 
             throw new ImageDeviationException("The deviation of the taken screenshot is too low (" . $deviationResult["deviation"] . "%).\nSee $compareScreenshotPath for a deviation screenshot.",
+                $identifier,
                 $this->getExpectedScreenshotPath($identifier),
                 $this->getScreenshotPath($identifier),
                 $compareScreenshotPath);
@@ -186,6 +187,7 @@ class VisualCeption extends CodeceptionModule
             $deviationResult["deviationImage"]->writeImage($compareScreenshotPath);
 
             throw new ImageDeviationException("The deviation of the taken screenshot is too hight (" . $deviationResult["deviation"] . "%).\nSee $compareScreenshotPath for a deviation screenshot.",
+                $identifier,
                 $this->getExpectedScreenshotPath($identifier),
                 $this->getScreenshotPath($identifier),
                 $compareScreenshotPath);


### PR DESCRIPTION
Solve tests with data providers and html result shows only last error

Example:

```php
class TestCest {
  /**
   * @example {"from": "PRG", "to": "MIL"}
   * @example {"from": "PRG", "to": "DXB"}
   */
  public function testMethod( WebGuy $I) {
    ...
    $I->dontSeeVisualChanges('Flights' . $example['from'] . $example['to'], '#id', []);
  }

}
```