### PR TITLE
Remove one second waiting in hidding elements

### DIFF
--- a/module/VisualCeption.php
+++ b/module/VisualCeption.php
@@ -381,8 +381,8 @@ class VisualCeption extends CodeceptionModule
     {
         foreach ($excludeElements as $element) {
             $this->hideElement($element);
-            $this->webDriverModule->waitForElementNotVisible($element);
         }
+        $this->webDriverModule->waitForElementNotVisible(array_pop($excludeElements));
     }
 
     /**
@@ -394,8 +394,8 @@ class VisualCeption extends CodeceptionModule
     {
         foreach ($excludeElements as $element) {
             $this->showElement($element);
-            $this->webDriverModule->waitForElementVisible($element);
         }
+        $this->webDriverModule->waitForElementVisible(array_pop($excludeElements));
     }
 
     /**

--- a/module/VisualCeption.php
+++ b/module/VisualCeption.php
@@ -382,7 +382,9 @@ class VisualCeption extends CodeceptionModule
         foreach ($excludeElements as $element) {
             $this->hideElement($element);
         }
-        $this->webDriverModule->waitForElementNotVisible(array_pop($excludeElements));
+        if (!empty($excludeElements)) {
+            $this->webDriverModule->waitForElementNotVisible(array_pop($excludeElements));
+        }
     }
 
     /**
@@ -395,7 +397,9 @@ class VisualCeption extends CodeceptionModule
         foreach ($excludeElements as $element) {
             $this->showElement($element);
         }
-        $this->webDriverModule->waitForElementVisible(array_pop($excludeElements));
+        if (!empty($excludeElements)) {
+            $this->webDriverModule->waitForElementVisible(array_pop($excludeElements));
+        }
     }
 
     /**

--- a/module/VisualCeption.php
+++ b/module/VisualCeption.php
@@ -381,8 +381,8 @@ class VisualCeption extends CodeceptionModule
     {
         foreach ($excludeElements as $element) {
             $this->hideElement($element);
+            $this->webDriverModule->waitForElementNotVisible($element);
         }
-        $this->webDriverModule->wait(1);
     }
 
     /**
@@ -394,8 +394,8 @@ class VisualCeption extends CodeceptionModule
     {
         foreach ($excludeElements as $element) {
             $this->showElement($element);
+            $this->webDriverModule->waitForElementVisible($element);
         }
-        $this->webDriverModule->wait(1);
     }
 
     /**


### PR DESCRIPTION
And tests are faster :)

**before:**
Codeception PHP Testing Framework v2.2.9
Powered by PHPUnit 5.7.15 by Sebastian Bergmann and contributors.

Acceptance Tests (7) 
✔</SimpleCept: Check visual changes inside element (9.36s)
✔</NotSameSizeCest: See visual changes after size changes (8.09s)
✔</TimeComparisonCest: See visual changes (8.03s)
✔</TimeComparisonCest: Dont see visual changes (8.21s)
✔</TimeComparisonCest: See visual changes and hide element (8.20s)
✔</TimeComparisonCest: Dont see visual changes and hide element (8.22s)
✔</WriteCurrentImageCest: Write current image file (3.68s)

Time: 55.46 seconds, Memory: 13.75MB

OK (7 tests, 6 assertions)


**after:**
Codeception PHP Testing Framework v2.2.9
Powered by PHPUnit 5.7.15 by Sebastian Bergmann and contributors.

Acceptance Tests (7)
✔</SimpleCept: Check visual changes inside element (5.07s)
✔</NotSameSizeCest: See visual changes after size changes (4.06s)
✔</TimeComparisonCest: See visual changes (4.01s)
✔</TimeComparisonCest: Dont see visual changes (4.27s)
✔</TimeComparisonCest: See visual changes and hide element (4.57s)
✔</TimeComparisonCest: Dont see visual changes and hide element (4.58s)
✔</WriteCurrentImageCest: Write current image file (1.68s)

Time: 30.17 seconds, Memory: 13.75MB

OK (7 tests, 6 assertions)


