### PR TITLE
Allow VisualCeption to work with any module that inherits from WebDriver

### DIFF
--- a/module/VisualCeption.php
+++ b/module/VisualCeption.php
@@ -113,17 +113,36 @@ class VisualCeption extends CodeceptionModule
      */
     public function _before(\Codeception\TestInterface $test)
     {
-        if (!$this->hasModule($this->config['module'])) {
+        $browserModule = $this->getBrowserModule();
+
+        if ($browserModule === null) {
             throw new \Codeception\Exception\ConfigurationException("VisualCeption uses the WebDriver. Please ensure that this module is activated.");
         }
         if (!class_exists('Imagick')) {
             throw new \Codeception\Exception\ConfigurationException("VisualCeption requires ImageMagick PHP Extension but it was not installed");
         }
 
-        $this->webDriverModule = $this->getModule($this->config['module']);
+        $this->webDriverModule = $browserModule;
         $this->webDriver = $this->webDriverModule->webDriver;
 
         $this->test = $test;
+    }
+
+    protected function getBrowserModule() {
+        if ($this->hasModule($this->config['module'])) {
+            return $this->getModule($this->config['module']);
+        }
+
+        foreach($this->getModules() as $module) {
+            if($module === $this) {
+                continue;
+            }
+            if($module instanceof WebDriver) {
+                return $module;
+            }
+        }
+
+        return null;
     }
     
     /**


### PR DESCRIPTION
The current implementation requires WebDriver module explicitly for VisualCeption to work. Unfortunately, this prevents modules like WpWebDriver from working with VisualCeption. Proposed change tries first to find WebDriver module, and if it fails to do so, it tries to use the first module that inherits from WebDriver.