### PR TITLE
Add old package name to "replace" in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,6 @@
   },
   "replace": {
     "codeception/visualception": "self.version"
-  }
+  },
   "minimum-stability": "dev"
 }

--- a/composer.json
+++ b/composer.json
@@ -26,5 +26,8 @@
   "conflict": {
     "codeception/codeception": "<5.0"
   },
+  "replace": {
+    "codeception/visualception": "self.version"
+  }
   "minimum-stability": "dev"
 }


### PR DESCRIPTION
In c5b02cd043e15326fb7e856c39b8fa02d1abed37 the composer package was renamed from "codeception/visualception" into "codeception/module-visualception".

This pull requests adds the old name to "replace" section in composer.json. With this change, composer knows that the new package "codeception/module-visualception" (new) must not be installed together with "codeception/visualception" (old)