### PR TITLE
[FEATURE] Improve support for pixel ratio > 1

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ modules:
 * **report** (default: `false`) When enabled an HTML report with diffs for failing tests is generated. Report is stored in `tests/_output/vcresult.html`.
 * **module** (default: `'WebDriver'`) module responsible for browser interaction, default: WebDriver.
 * **fullScreenShot** (default: `false`) fullpage screenshot for Chrome and Firefox
+* **downscalePixelRatio** (default: `false`) automatically downscales screenshots to the pixel ratio "1". This can be helpful if you or your team are running the test on devices with different pixel densities. When this feature is enabled, screenshots from devices with higher pixel densities are automatically resized to provide more comparable images. Please note that scaled images will never be absolutely identical to the original, you need to set "maxiumDeviation" carefully if you want to pass your tests.  
 
 ## Usage
 


### PR DESCRIPTION
The first part of the PR improves generating screenshots for all devices with pixel ratio > 1. The lines https://github.com/koehnlein/VisualCeption/commit/c15c2944fd39e10fcb848a647eae6ad148fc096f#diff-23be3accec9cccd7a4b66e668a0a62586dec7eb7f4d2fc2b47419a46c6f2feb1R508-R513 include the pixel ratio when calculating the image cropping. Before this change, e.g. with "pixel ratio = 2", only the upper left quarter of the requested area was kept after cropping.

The second part is a new configuration option, described in readme.md:

> **downscalePixelRatio** (default: `false`) automatically downscales screenshots to the pixel ratio "1". This can be helpful if you or your team are running the test on devices with different pixel densities. When this feature is enabled, screenshots from devices with higher pixel densities are automatically resized to provide more comparable images. Please note that scaled images will never be absolutely identical to the original, you need to set "maxiumDeviation" carefully if you want to pass your tests.  
